### PR TITLE
style: clampでフォントサイズをレスポンシブ対応に変更

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -16,9 +16,9 @@
   --color-gray500: #6b6b6b;
 
   /* Font Size */
-  --fs-heading: 24px;
-  --fs-body: 16px;
-  --fs-small: 14px;
+  --fs-l: clamp(1.25rem, 1.162rem + 0.38vw, 1.5rem);
+  --fs-m: clamp(0.875rem, 0.831rem + 0.19vw, 1rem);
+  --fs-s: clamp(0.75rem, 0.706rem + 0.19vw, 0.875rem);
 
   /* Font Weight */
   --fw-bold: 700;
@@ -55,7 +55,7 @@ img{
 ==================================*/
 .main{
   display: grid;
-  grid-template-columns: 1fr minmax(auto, 384px) 1fr;
+  grid-template-columns: minmax(24px, 1fr) minmax(auto, 384px) minmax(24px, 1fr);
 
   > *{
     grid-column: 1/-1;
@@ -111,7 +111,7 @@ img{
 /* tag */
 .tag{
   grid-area: tag;
-  font-size: var(--fs-small);
+  font-size: var(--fs-s);
   font-weight: var(--fw-bold);
   background-color: var(--color-yellow);
   padding: 4px 12px;
@@ -122,13 +122,13 @@ img{
 /* date */
 .date{
   grid-area: date;
-  font-size: var(--fs-small);
+  font-size: var(--fs-s);
 }
 
 /* title */
 .title{
   grid-area: title;
-  font-size: var(--fs-heading);
+  font-size: var(--fs-l);
   font-weight: var(--fw-bold);
   cursor: pointer;
   transition: all 0.3s ease;
@@ -142,7 +142,7 @@ img{
 .text{
   grid-area: text;
   color: var(--color-gray500);
-  font-size: var(--fs-body);
+  font-size: var(--fs-m);
 }
 
 /* avatar */
@@ -156,7 +156,7 @@ img{
 .name{
   grid-area: name;
   align-self: center;
-  font-size: var(--fs-small);
+  font-size: var(--fs-s);
   font-weight: var(--fw-bold);
 }
 


### PR DESCRIPTION
### 変更箇所
- `:root` に clamp() を使用したフォントサイズのカスタムプロパティ（--fs-l, --fs-m, --fs-s）に変更した

### 背景
フォントサイズを画面幅に応じて変化させるため、`clamp()` を使用してフォントサイズを可変対応させ、  
より柔軟なデザイン表現が可能になるよう改善しました